### PR TITLE
Updates Android and iOS SDK and related dependencies.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
 		<WarningLevel>3</WarningLevel>
 		<DefaultLanguage>en-us</DefaultLanguage>
 
-		<_IosSdkVersion>25.2.0</_IosSdkVersion>
-		<_AndroidSdkVersion>22.4.0</_AndroidSdkVersion>
+		<_IosSdkVersion>25.6.0</_IosSdkVersion>
+		<_AndroidSdkVersion>22.7.0</_AndroidSdkVersion>
 
 		<GenerateRequiresPreviewFeaturesAttribute>false</GenerateRequiresPreviewFeaturesAttribute>
 		<EnablePreviewFeatures>false</EnablePreviewFeatures>

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Maintaining this on our own isn’t feasible, so we’re turning it into a commu
 
 This library uses the following Stripe SDK versions for each platform:
 
-- **Stripe Android SDK**: `21.29.1`  
-- **Stripe iOS SDK**: `24.25.0`
+- **Stripe Android SDK**: `22.7.0`  
+- **Stripe iOS SDK**: `25.6.0`
 
 ## Long path error
 You can face issue with long paths, similar to that:

--- a/src/G1.Stripe.Android.Bindings/G1.Stripe.Android.Bindings.csproj
+++ b/src/G1.Stripe.Android.Bindings/G1.Stripe.Android.Bindings.csproj
@@ -41,47 +41,47 @@
 		<AndroidMavenLibrary Include="com.nimbusds:nimbus-jose-jwt" Version="10.4.2" Bind="False" />
 		
 		<!-- Android dependencies -->
-		<PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.10.1.2" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Compose" Version="2.8.7.4" />
-		<PackageReference Include="Xamarin.KotlinX.Coroutines.Play.Services" Version="1.10.2" />
+		<PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.12.2.1" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Compose" Version="2.10.0.1" />
+		<PackageReference Include="Xamarin.KotlinX.Coroutines.Play.Services" Version="1.10.2.2" />
 		<PackageReference Include="Xamarin.KotlinX.Serialization.Json" Version="1.8.1" />
 		<PackageReference Include="Xamarin.AndroidX.Navigation.Compose" Version="2.8.9.1" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Ktx" Version="2.8.7.4" />
-		<PackageReference Include="Xamarin.KotlinX.Coroutines.Core" Version="1.10.2" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Ktx" Version="2.10.0.1" />
+		<PackageReference Include="Xamarin.KotlinX.Coroutines.Core" Version="1.10.2.2" />
 
 		<!-- Microsoft-supported dependencies for Stripe SDK -->
-		<PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.2.0.1" />
-		<PackageReference Include="Xamarin.Kotlin.StdLib.Jdk7" Version="2.2.0.1" />
-		<PackageReference Include="Xamarin.Kotlin.StdLib.Jdk8" Version="2.2.0.1" />
+		<PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.3.0.1" />
+		<PackageReference Include="Xamarin.Kotlin.StdLib.Jdk7" Version="2.3.0.1" />
+		<PackageReference Include="Xamarin.Kotlin.StdLib.Jdk8" Version="2.3.0.1" />
 		<PackageReference Include="Xamarin.AndroidX.Compose.Material3" Version="1.3.1.1" />
 		<PackageReference Include="Xamarin.AndroidX.DataBinding.ViewBinding" Version="8.13.1" />
-		<PackageReference Include="Xamarin.AndroidX.Annotation" Version="1.9.1.5" />
+		<PackageReference Include="Xamarin.AndroidX.Annotation" Version="1.9.1.6" />
 		<PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.7" />
 		<PackageReference Include="Xamarin.AndroidX.Browser" Version="1.8.0.10" />
 		<PackageReference Include="Xamarin.AndroidX.ConstraintLayout" Version="2.2.0.2" />
-		<PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.6" />
+		<PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.9.1" />
 		<PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.3.2.10" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" Version="2.8.7.4" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.8.7.4" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.8.7.4" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" Version="2.10.0.1" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.10.0.1" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.10.0.1" />
 		<PackageReference Include="Xamarin.AndroidX.Activity.Compose" Version="1.10.1.2" />
-		<PackageReference Include="Xamarin.AndroidX.Compose.Foundation" Version="1.7.8" />
-		<PackageReference Include="Xamarin.AndroidX.Compose.Material" Version="1.7.8" />
+		<PackageReference Include="Xamarin.AndroidX.Compose.Foundation" Version="1.9.4" />
+		<PackageReference Include="Xamarin.AndroidX.Compose.Material" Version="1.9.4" />
 		<PackageReference Include="Xamarin.AndroidX.Compose.Material.Icons.Core" Version="1.7.8" />
-		<PackageReference Include="Xamarin.AndroidX.Compose.UI" Version="1.7.8.2" />
+		<PackageReference Include="Xamarin.AndroidX.Compose.UI" Version="1.9.4" />
 		<PackageReference Include="Xamarin.AndroidX.WebKit" Version="1.14.0" />
 		<PackageReference Include="Xamarin.Google.Dagger" Version="2.55.0" />
-		<PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.10.2" />
+		<PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.10.2.2" />
 		<PackageReference Include="Xamarin.Google.Android.Material" Version="1.12.0.2" />
 		<PackageReference Include="Xamarin.GooglePlayServices.Wallet" Version="119.4.0.6" />
-		<PackageReference Include="Xamarin.AndroidX.Compose.UI.ViewBinding" Version="1.7.8" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" Version="2.8.7.4" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.8.7.4" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.8.7.4" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.8.7.4" />
-		<PackageReference Include="Xamarin.AndroidX.Compose.UI.Tooling.Preview" Version="1.7.8" />
-		<PackageReference Include="Xamarin.AndroidX.Core.Core.Ktx" Version="1.16.0.2" />
-		<PackageReference Include="Xamarin.AndroidX.Core" Version="1.16.0.2" />
+		<PackageReference Include="Xamarin.AndroidX.Compose.UI.ViewBinding" Version="1.9.4" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" Version="2.10.0.1" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.10.0.1" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.10.0.1" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.10.0.1" />
+		<PackageReference Include="Xamarin.AndroidX.Compose.UI.Tooling.Preview" Version="1.9.4" />
+		<PackageReference Include="Xamarin.AndroidX.Core.Core.Ktx" Version="1.17.0.1" />
+		<PackageReference Include="Xamarin.AndroidX.Core" Version="1.17.0.1" />
 		<PackageReference Include="Xamarin.Google.Accompanist.SystemUIController" Version="0.36.0" />
 		<PackageReference Include="Xamarin.Google.Accompanist.FlowLayout" Version="0.36.0" />
 		<PackageReference Include="Xamarin.Google.Android.Play.Integrity" Version="1.4.0.5" />

--- a/src/G1.Stripe.Android.Bindings/Transforms/Metadata.xml
+++ b/src/G1.Stripe.Android.Bindings/Transforms/Metadata.xml
@@ -54,4 +54,7 @@
 
 	<attr path="/api/package[@name='com.stripe.android.challenge.passive']/class[@name='PassiveChallengeActivityContract']" name="extends">java.lang.Object</attr>
 	<attr path="/api/package[@name='com.stripe.android.challenge.passive.warmer.activity']/class[@name='PassiveChallengeWarmerContract']" name="extends">java.lang.Object</attr>
+	
+	<attr path="/api/package[@name='com.stripe.android']/class[@name='DefaultCardFundingFilter']/method[@name='allowedFundingTypesDisplayMessage' and count(parameter)=0]"
+        name="managedReturn">Java.Lang.Integer</attr>
 </metadata>


### PR DESCRIPTION
Updates the Stripe Android and iOS bindings project to use newer versions of the SDK and supporting libraries.

This ensures compatibility with the latest Android features and improvements, and incorporates the newest Kotlin standard libraries.

Android: 22.4.0 -> 22.7.0
iOS: 25.2.0 -> 25.6.0

Fixing this: https://github.com/stripe/stripe-android/issues/11843#issuecomment-3806099601

@hitchhiker @dmitry-bym 
